### PR TITLE
Fix Repeated History Items on Input

### DIFF
--- a/src/app/features/input/input.component.ts
+++ b/src/app/features/input/input.component.ts
@@ -16,8 +16,11 @@ export class InputComponent implements OnInit {
   ngOnInit(): void {}
 
   submitInput(event: Event) {
-    this.history.push(this.input);
-    this.historyPosition = this.history.length;
+    if (this.getLastHistory() !== this.input && this.input.length > 0) {
+      this.history.push(this.input);
+      this.historyPosition = this.history.length;
+    }
+
     console.log(this.input);
     if (event.target) {
       (event.target as HTMLInputElement).select();
@@ -66,5 +69,10 @@ export class InputComponent implements OnInit {
       this.historyPosition = this.historyPosition+1;
     }
     this.injectHistory();
+  }
+
+  getLastHistory(): string | null {
+    if (this.history.length === 0) return null;
+    return this.history[this.history.length - 1];
   }
 }


### PR DESCRIPTION
Adds logic to history handling so that repeated inputs don't add additional history items. i.e., if you send 'east' 5x, navigating up through the history will only have one instance of 'east'